### PR TITLE
Issue #7/ added focus for input field

### DIFF
--- a/app/script.js
+++ b/app/script.js
@@ -109,6 +109,8 @@ function addTask() {
     saveButton.id = 'saveButton';
     saveButton.innerHTML = '<i class="fas fa-check"></i>';
 
+    setTimeout(() => taskInput.focus(), 0);
+
     // Function to handle saving the task
     const saveTaskHandler = () => {
         const taskText = taskInput.value.trim();


### PR DESCRIPTION
This PR enables direct focus to input field of an open task so the user doesn't need to click the input field every time. They can now simply start typing after clicking the add task button.


https://github.com/user-attachments/assets/01c61241-4533-4ea4-9471-a0551200eb4f

